### PR TITLE
Fix no cancel button on Android alert

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -120,7 +120,7 @@ export function askAppChoice ({ dialogTitle, dialogMessage, cancelText, appsWhit
     }
 
     const options = availableApps.map((app) => ({ text: titles[app], onPress: () => resolve(app) }))
-    options.push({ text: cancelText, onPress: () => resolve(null), style: 'cancel' })
+    options.unshift({ text: cancelText, onPress: () => resolve(null), style: 'cancel' })
     return Alert.alert(dialogTitle, dialogMessage, options, { onDismiss: () => resolve(null) })
   })
 }


### PR DESCRIPTION
Add cancel option at first position of Android alert options.

Fix this issue : https://github.com/tschoffelen/react-native-map-link/issues/114
