### PR TITLE
Add override option for app titles, #120

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ showLocation({
     dialogTitle: 'This is the dialog Title', // optional (default: 'Open in Maps')
     dialogMessage: 'This is the amazing dialog Message', // optional (default: 'What app would you like to use?')
     cancelText: 'This is the cancel button text', // optional (default: 'Cancel')
-    appsWhiteList: ['google-maps'] // optionally you can set which apps to show (default: will show all supported apps installed on device)
+    appsWhiteList: ['google-maps'], // optionally you can set which apps to show (default: will show all supported apps installed on device)
+    appTitles: { 'google-maps': 'My custom Google Maps title' } // optionally you can override default app titles
     // app: 'uber'  // optionally specify specific app to use
 })
 ```

--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ showLocation({
     dialogTitle: 'This is the dialog Title', // optional (default: 'Open in Maps')
     dialogMessage: 'This is the amazing dialog Message', // optional (default: 'What app would you like to use?')
     cancelText: 'This is the cancel button text', // optional (default: 'Cancel')
-    appsWhiteList: ['google-maps'], // optionally you can set which apps to show (default: will show all supported apps installed on device)
-    appTitles: { 'google-maps': 'My custom Google Maps title' } // optionally you can override default app titles
+    appsWhiteList: ['google-maps'] // optionally you can set which apps to show (default: will show all supported apps installed on device)
+    // appTitles: { 'google-maps': 'My custom Google Maps title' } // optionally you can override default app titles
     // app: 'uber'  // optionally specify specific app to use
 })
 ```

--- a/docs/popup.md
+++ b/docs/popup.md
@@ -19,6 +19,7 @@ import { Popup } from 'react-native-map-link';
     }}
     appsWhiteList={[ /* Array of apps (apple-maps, google-maps, etc...) that you want
     to show in the popup, if is undefined or an empty array it will show all supported apps installed on device.*/ ]}
+    appTitles: {{ /* Optional: you can override app titles. */ }}
     options={{ /* See `showLocation` method above, this accepts the same options. */ }}
     style={{ /* Optional: you can override default style by passing your values. */ }}
 />

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,6 +15,7 @@ interface Options {
     dialogMessage?: string
     cancelText?: string
     appsWhiteList?: string[]
+    appTitles?: { [key: string]: string };
 }
 
 interface PopupStyleProp {
@@ -40,7 +41,8 @@ interface PopupProps {
     style?: PopupStyleProp,
     modalProps?: object,
     options: Options,
-    appsWhiteList: string[]
+    appsWhiteList: string[],
+    appTitles?: { [key: string]: string }
 }
 
 export function showLocation(options: Options): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ interface Options {
     dialogMessage?: string
     cancelText?: string
     appsWhiteList?: string[]
-    appTitles?: { [key: string]: string };
+    appTitles?: { [key: string]: string }
 }
 
 interface PopupStyleProp {

--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -18,7 +18,7 @@ import Modal from 'react-native-modal'
 
 import { getAvailableApps, checkNotSupportedApps } from '../utils'
 import { showLocation } from '../index'
-import { titles, icons, generatePrefixes } from '../constants'
+import { generateTitles, icons, generatePrefixes } from "../constants";
 
 const SCREEN_HEIGHT = Dimensions.get('screen').height
 
@@ -35,7 +35,8 @@ export default class Popup extends React.Component {
 
     this.state = {
       apps: [],
-      loading: true
+      loading: true,
+      titles: generateTitles(props.appTitles),
     }
 
     this._renderAppItem = this._renderAppItem.bind(this)
@@ -100,7 +101,7 @@ export default class Popup extends React.Component {
             source={icons[item]}
           />
         </View>
-        <Text style={[styles.itemText, this.props.style.itemText]}>{titles[item]}</Text>
+        <Text style={[styles.itemText, this.props.style.itemText]}>{this.state.titles[item]}</Text>
       </TouchableOpacity>
     )
   }

--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -18,7 +18,7 @@ import Modal from 'react-native-modal'
 
 import { getAvailableApps, checkNotSupportedApps } from '../utils'
 import { showLocation } from '../index'
-import { generateTitles, icons, generatePrefixes } from "../constants";
+import { generateTitles, icons, generatePrefixes } from '../constants'
 
 const SCREEN_HEIGHT = Dimensions.get('screen').height
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -28,18 +28,20 @@ export function prefixForGoogleMaps (alwaysIncludeGoogle) {
     : 'https://maps.google.com/'
 }
 
-export const titles = {
-  'apple-maps': 'Apple Maps',
-  'google-maps': 'Google Maps',
-  citymapper: 'Citymapper',
-  uber: 'Uber',
-  lyft: 'Lyft',
-  transit: 'The Transit App',
-  waze: 'Waze',
-  yandex: 'Yandex.Navi',
-  moovit: 'Moovit',
-  'yandex-maps': 'Yandex Maps',
-  kakaomap: 'Kakao Maps'
+export function generateTitles (titles) {
+  return Object.assign({
+    'apple-maps': 'Apple Maps',
+    'google-maps': 'Google Maps',
+    citymapper: 'Citymapper',
+    uber: 'Uber',
+    lyft: 'Lyft',
+    transit: 'The Transit App',
+    waze: 'Waze',
+    yandex: 'Yandex.Navi',
+    moovit: 'Moovit',
+    'yandex-maps': 'Yandex Maps',
+    kakaomap: 'Kakao Maps'
+  }, titles || {});
 }
 
 export const icons = {
@@ -55,3 +57,5 @@ export const icons = {
   'yandex-maps': require('./images/yandex-maps.png'),
   kakaomap: require('./images/kakao-map.png')
 }
+
+export const appKeys = Object.keys(icons);

--- a/src/constants.js
+++ b/src/constants.js
@@ -29,7 +29,7 @@ export function prefixForGoogleMaps (alwaysIncludeGoogle) {
 }
 
 export function generateTitles (titles) {
-  return Object.assign({
+  return {
     'apple-maps': 'Apple Maps',
     'google-maps': 'Google Maps',
     citymapper: 'Citymapper',
@@ -40,8 +40,9 @@ export function generateTitles (titles) {
     yandex: 'Yandex.Navi',
     moovit: 'Moovit',
     'yandex-maps': 'Yandex Maps',
-    kakaomap: 'Kakao Maps'
-  }, titles || {});
+    kakaomap: 'Kakao Maps',
+    ...(titles || {})
+  }
 }
 
 export const icons = {

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@
 
 import { Linking } from 'react-native'
 
-import { isIOS, generatePrefixes } from './constants'
+import { isIOS, generatePrefixes, generateTitles } from './constants'
 import { askAppChoice, checkOptions } from './utils'
 
 /**
@@ -24,6 +24,7 @@ import { askAppChoice, checkOptions } from './utils'
  *     dialogMessage: string | undefined | null
  *     cancelText: string | undefined | null
  *     appsWhiteList: array | undefined | null
+ *     appTitles: object | undefined | null
  * }} options
  */
 export async function showLocation (options) {
@@ -59,8 +60,9 @@ export async function showLocation (options) {
       dialogMessage,
       cancelText,
       appsWhiteList,
-      prefixes
-    })
+      prefixes,
+      appTitles: generateTitles(options.appTitles)
+    });
   }
 
   let url = null

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,7 +4,7 @@
 
 import { Linking, ActionSheetIOS, Alert } from 'react-native'
 
-import { titles, isIOS } from './constants'
+import { appKeys, isIOS } from "./constants"
 
 /**
  * Get available navigation apps.
@@ -49,7 +49,7 @@ function isAppInstalled (app, prefixes) {
  * @returns {boolean}
  */
 function isSupportedApp (app) {
-  return Object.keys(titles).includes(app)
+  return appKeys.includes(app)
 }
 
 /**
@@ -71,7 +71,7 @@ export function checkNotSupportedApps (apps) {
   const notSupportedApps = getNotSupportedApps(apps)
   if (notSupportedApps.length) {
     throw new MapsException(
-      `appsWhiteList [${notSupportedApps}] are not supported apps, please provide some of the supported apps [${Object.keys(titles)}]`
+      `appsWhiteList [${notSupportedApps}] are not supported apps, please provide some of the supported apps [${appKeys}]`
     )
   }
 }
@@ -83,11 +83,12 @@ export function checkNotSupportedApps (apps) {
  *     message: string | undefined | null
  *     cancelText: string | undefined | null
  *     appsWhiteList: string[] | null
- *     prefixes: string[]
+ *     prefixes: string[],
+ *     appTitles: object | undefined | null
  * }} options
  * @returns {Promise}
  */
-export function askAppChoice ({ dialogTitle, dialogMessage, cancelText, appsWhiteList, prefixes }) {
+export function askAppChoice ({ dialogTitle, dialogMessage, cancelText, appsWhiteList, prefixes, appTitles }) {
   return new Promise(async (resolve) => {
     let availableApps = await getAvailableApps(prefixes)
 
@@ -101,7 +102,7 @@ export function askAppChoice ({ dialogTitle, dialogMessage, cancelText, appsWhit
     }
 
     if (isIOS) {
-      const options = availableApps.map((app) => titles[app])
+      const options = availableApps.map(app => appTitles[app])
       options.push(cancelText)
 
       ActionSheetIOS.showActionSheetWithOptions({
@@ -119,7 +120,10 @@ export function askAppChoice ({ dialogTitle, dialogMessage, cancelText, appsWhit
       return
     }
 
-    const options = availableApps.map((app) => ({ text: titles[app], onPress: () => resolve(app) }))
+    const options = availableApps.map(app => ({
+      text: appTitles[app],
+      onPress: () => resolve(app)
+    }))
     options.push({ text: cancelText, onPress: () => resolve(null), style: 'cancel' })
     return Alert.alert(dialogTitle, dialogMessage, options, { onDismiss: () => resolve(null) })
   })
@@ -164,6 +168,9 @@ export function checkOptions (options, prefixes) {
   }
   if ('appsWhiteList' in options && options.appsWhiteList) {
     checkNotSupportedApps(options.appsWhiteList)
+  }
+  if ('appTitles' in options && options.appTitles && typeof options.appTitles !== 'object') {
+    throw new MapsException('Option `appTitles` should be of type `object`.');
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -170,7 +170,7 @@ export function checkOptions (options, prefixes) {
     checkNotSupportedApps(options.appsWhiteList)
   }
   if ('appTitles' in options && options.appTitles && typeof options.appTitles !== 'object') {
-    throw new MapsException('Option `appTitles` should be of type `object`.');
+    throw new MapsException('Option `appTitles` should be of type `object`.')
   }
 }
 


### PR DESCRIPTION
Hello,

As I needed this feature, I added the possibility to override app titles.

You can use the new `appTitles` argument to pass an object with app code as key and custom title as value :

```js
showLocation({
  latitude: 38.8976763,
  longitude: -77.0387185,
  title: 'The White House', // optional
  dialogTitle: 'This is the dialog Title', // optional (default: 'Open in Maps')
  dialogMessage: 'This is the amazing dialog Message', // optional (default: 'What app would you like to use?')
  cancelText: 'This is the cancel button text', // optional (default: 'Cancel')
  appTitles: { 'google-maps': 'My custom Google Maps title' }
});
```

With Popup:

```ts
import { Popup } from 'react-native-map-link';

<Popup
    isVisible={this.state.isVisible}
    onCancelPressed={() => this.setState({ isVisible: false })}
    onAppPressed={() => this.setState({ isVisible: false })}
    onBackButtonPressed={() => this.setState({ isVisible: false })}
    modalProps={{ // you can put all react-native-modal props inside.
        animationIn: 'slideInUp'
    }}
    appsWhiteList={[ /* Array of apps (apple-maps, google-maps, etc...) that you want
    to show in the popup, if is undefined or an empty array it will show all supported apps installed on device.*/ ]}
    appTitles={{ waze: 'My custom Waze title' }}
    options={{ /* See `showLocation` method above, this accepts the same options. */ }}
    style={{ /* Optional: you can override default style by passing your values. */ }}
/>
```

This allows you to translate app names.

Waiting for your feedbacks. :)

---

Linked to issue #120.