### PR TITLE
Custom Header and Footer Props added to Popup

### DIFF
--- a/docs/popup.md
+++ b/docs/popup.md
@@ -44,3 +44,29 @@ Also, you can customize the styling of the popup by passing an object like this 
     activityIndicatorContainer: {}
 }
 ```
+
+### Custom Header and Footer Components
+
+You can also make use of your own Header and Footer components by adding the `customHeader` and/or `customFooter` Props to the Popup component. See the example below:
+
+```js
+
+renderHeader() {
+  return <MyCustomHeaderComponent/>
+}
+
+renderFooter() {
+  return <MyCustomFooterComponent/>
+}
+
+render() {
+  return (
+    <Popup
+      ...
+      customHeader={this.renderHeader()}
+      customFooter={this.renderFooter()}
+    />
+  );
+}
+
+```

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,8 @@ interface PopupStyleProp {
 interface PopupProps {
     isVisible: boolean,
     showHeader?: boolean,
+    customHeader?: React.ReactNode,
+    customFooter?:  React.ReactNode,
     onCancelPressed: () => void,
     onBackButtonPressed: () => void,
     onAppPressed: () => void,

--- a/src/components/Popup.js
+++ b/src/components/Popup.js
@@ -54,9 +54,12 @@ export default class Popup extends React.Component {
   }
 
   _renderHeader () {
-    const { showHeader, options } = this.props
+    const { showHeader, customHeader, options } = this.props
     if (!showHeader) {
       return null
+    }
+    if (customHeader) {
+      return customHeader;
     }
 
     const dialogTitle = options.dialogTitle && options.dialogTitle.length
@@ -119,6 +122,14 @@ export default class Popup extends React.Component {
     )
   }
 
+  _renderFooter () {
+    const { customFooter } = this.props
+    if (customFooter) {
+      return customFooter;
+    }
+   return this._renderCancelButton();
+  }
+
   _onAppPressed ({ app }) {
     showLocation({ ...this.props.options, app })
     this.props.onAppPressed(app)
@@ -140,7 +151,7 @@ export default class Popup extends React.Component {
           {loading ? (
             <ActivityIndicator style={[styles.activityIndicatorContainer, this.props.style.activityIndicatorContainer]}/>
           ) : this._renderApps()}
-          {this._renderCancelButton()}
+          {this._renderFooter()}
         </View>
       </Modal>
     )
@@ -150,6 +161,8 @@ export default class Popup extends React.Component {
 Popup.propTypes = {
   isVisible: PropTypes.bool,
   showHeader: PropTypes.bool,
+  customHeader: PropTypes.element,
+  customFooter: PropTypes.element,
   onBackButtonPressed: PropTypes.func,
   onAppPressed: PropTypes.func,
   onCancelPressed: PropTypes.func,
@@ -162,6 +175,8 @@ Popup.propTypes = {
 Popup.defaultProps = {
   isVisible: false,
   showHeader: true,
+  customHeader: null,
+  customFooter: null,
   style: {
     container: {},
     itemContainer: {},


### PR DESCRIPTION
To allow for more flexibility a custom header and footer prop can be added. This allows the developer the freedom to use their own components in the Modal if necessary.