### PR TITLE
Use address with directions mode if provided

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -291,6 +291,8 @@ export const generateMapUrl = ({
         url += sourceLatLng ? `&origin=${sourceLatLng}` : '';
         if (!googleForceLatLon && title) {
           url += `&destination=${encodedTitle}`;
+        } else if (!googleForceLatLon && address) {
+          url += `&destination=${address}`;
         } else {
           url += `&destination=${latlng}`;
         }


### PR DESCRIPTION
```
showLocation({
  address: '1600 Pennsylvania Avenue NW, Washington, DC 20500',
  directionsMode: 'car',
});
```

returns url `https://www.google.com/maps/dir/?api=1&destination=undefined,undefined&travelmode=driving`

instead it should return `https://www.google.com/maps/dir/?api=1&destination=1600%20Pennsylvania%20Avenue%20NW%2C%20Washington%2C%20DC%2020500&travelmode=driving`